### PR TITLE
Update JAD to 1.3.0

### DIFF
--- a/javadecompiler-gui/src/tools/chocolateyInstall.ps1
+++ b/javadecompiler-gui/src/tools/chocolateyInstall.ps1
@@ -1,26 +1,18 @@
-﻿
-$version = '1.2.0';
-$packageName = 'javadecompiler-gui'; # arbitrary name for the package, used in messages
-$url = "https://github.com/java-decompiler/jd-gui/releases/download/v1.2.0/jd-gui-windows-1.2.0.zip";
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-$unzipLocation = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)";
-$shortcutFilePath = "$([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::StartMenu))\Programs\JavaDecompiler.lnk";
-$targetPath = "${unzipLocation}\jd-gui.exe";
-
-try { 
-
-  Install-ChocolateyZipPackage $packageName $url $unzipLocation;
-
-  $global:WshShell = New-Object -com "WScript.Shell"
-  $lnk = $global:WshShell.CreateShortcut($shortcutFilePath)
-  $lnk.TargetPath = $targetPath
-  $lnk.Save()
-
-  #Install-ChocolateyShortcut -shortcutFilePath "$([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::StartMenu))\Programs\JavaDecompiler.lnk" -targetPath "${unzipLocation}\jd-gui.exe";
-  # This will create a new shortcut at the location of "C:\test.lnk" and link to the file located at "C:\text.exe"
-
-  Write-ChocolateySuccess "$packageName";
-} catch {
-  Write-ChocolateyFailure "$packageName" "$($_.Exception.Message)";
-  throw;
+$packageArgs = @{
+  packageName   = 'javadecompiler-gui'
+  url           = 'https://github.com/java-decompiler/jd-gui/releases/download/v1.3.0/jd-gui-windows-1.3.0.zip'
+  checksum      = '478ff198ed9c9a9945cc55ae1fb8b9b6'
+  checksumType  = 'md5'
+  unzipLocation = $toolsDir
 }
+
+$menuPrograms = [environment]::GetFolderPath([environment+specialfolder]::Programs)
+$shotrcutArgs = @{
+  shortcutFilePath = "$menuPrograms\Java Decompiler.lnk"
+  targetPath       = "$toolsDir\jd-gui-windows-1.3.0\jd-gui.exe"
+}
+
+Install-ChocolateyZipPackage @packageArgs
+Install-ChocolateyShortcut @shotrcutArgs

--- a/javadecompiler-gui/src/tools/chocolateyUninstall.ps1
+++ b/javadecompiler-gui/src/tools/chocolateyUninstall.ps1
@@ -1,0 +1,12 @@
+$packageArgs = @{
+  packageName = 'javadecompiler-gui'
+  zipFileName = 'jd-gui-windows-1.3.0.zip'
+}
+
+$menuPrograms = [environment]::GetFolderPath([environment+specialfolder]::Programs)
+$shortcutFilePath = "$menuPrograms\Java Decompiler.lnk"
+
+UnInstall-ChocolateyZipPackage @packageArgs
+If (Test-Path $shortcutFilePath) {
+  Remove-Item $shortcutFilePath
+}

--- a/javadecompiler-gui/src/workrave.nuspec
+++ b/javadecompiler-gui/src/workrave.nuspec
@@ -1,25 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Do not remove this test for UTF-8: if ??? doesn?t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>javadecompiler-gui</id>
     <title>Java Decompiler GUI</title>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <authors>Emmanuel Dupuy</authors>
     <owners>Surov Vladimir</owners>
     <summary>JD (Java Decompiler) is a Decompiler for the Java programming language.</summary>
     <description>JD (Java Decompiler) is a Decompiler for the Java programming language.</description>
     <projectUrl>http://jd.benow.ca/</projectUrl>
     <tags>java decompiler gui</tags>
-    <copyright>2008-2013 Emmanuel Dupuy</copyright>
-    <licenseUrl>http://en.wikipedia.org/wiki/Java_Decompiler</licenseUrl>
+    <copyright>2008-2015 Emmanuel Dupuy</copyright>
+    <licenseUrl>http://opensource.org/licenses/GPL-3.0</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>http://jd.benow.ca/img/Icon_java_64.png</iconUrl>
-    <!--<dependencies>
-      <dependency id="" version="" />
-    </dependencies>-->
-    <releaseNotes></releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
Hi,
Changes:
- update to JAD 1.3.0
- add uninstall script
- remove deprecated API
- clean nuspec (correct license, remove unused comments)

Regards,
   Adam Gabryś
