### PR TITLE
Update to AIMP 4.02 v1725

### DIFF
--- a/aimp/src/tools/chocolateyUninstall.ps1
+++ b/aimp/src/tools/chocolateyUninstall.ps1
@@ -1,17 +1,16 @@
-﻿$packageName = 'aimp';
+$packageName = 'aimp';
 $installerType = 'exe';
 $validExitCodes = @(0);
 
 try {
-	$hklm = "hklm:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\AIMP3";
+	$hklm = "hklm:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\AIMP";
 	if (Get-ProcessorBits 64) {
-  		$hklm = "hklm:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\AIMP3";
+  		$hklm = "hklm:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\AIMP";
 	}
 	$file = (Get-ItemProperty -Path $hklm).UninstallString;
 	Uninstall-ChocolateyPackage -PackageName $packageName -FileType $installerType -validExitCodes $validExitCodes -File $file;
   
 	Write-ChocolateySuccess $packageName;
 } catch {
-	Write-ChocolateyFailure $packageName "$($_.Exception.Message)";
-	throw;
+throw $_.Exception
 }


### PR DESCRIPTION
- HLKM keys modified (uninstall keys name have been changed)
- Replaced "Write-ChocolateyFailure" (deprecated)
